### PR TITLE
fix parse data error in 64bit device

### DIFF
--- a/samples/cocos2d-2.1beta3-x-2.1.1/super-anim-samples/SuperAnim/SuperAnimCore.cpp
+++ b/samples/cocos2d-2.1beta3-x-2.1.1/super-anim-samples/SuperAnim/SuperAnimCore.cpp
@@ -410,7 +410,7 @@ namespace SuperAnim {
 		uchar					ReadByte() const;
 		bool					ReadBoolean() const;
 		short					ReadShort() const;
-		long					ReadLong() const;
+		int                     ReadLong() const;
 		std::string				ReadString() const;	
 	};
 	
@@ -494,12 +494,12 @@ namespace SuperAnim {
 		return aShort;	
 	}
 	
-	long BufferReader::ReadLong() const
+	int BufferReader::ReadLong() const
 	{
-		long aLong = ReadByte();
-		aLong |= ((long) ReadByte()) << 8;
-		aLong |= ((long) ReadByte()) << 16;
-		aLong |= ((long) ReadByte()) << 24;
+		int aLong = ReadByte();
+		aLong |= ((int) ReadByte()) << 8;
+		aLong |= ((int) ReadByte()) << 16;
+		aLong |= ((int) ReadByte()) << 24;
 		
 		return aLong;
 	}


### PR DESCRIPTION
Hi Raymond,

This is a critical bug fix when running on 64 bit environment. Here is the explanation:

On 32 bit environment, the size of long type is 4 bytes. When you read a 4 bytes data from .sam file and stores it in a variable of long type, it works well.

But on 64 bit environment, the size of long type changes to 8 bytes. If the 4 bytes data you read is a negative number like -2:
0xfffffffe
When storing it to a variable of long type using ReadLong() function, it becomes:
0x00000000fffffffe
Now it becomes a very big positive number.

If you run some demos on iPhone5 or iPhone6, you might find some animations are distorted terribly due to the wrong parsed data. But if you run them on iTouch5, everything looks good. Because iPhone5 and iPhone6 supports 64 bit while iTouch only supports 32 bit.

Please merge this patch to your branch.

Thanks for your work!
